### PR TITLE
Fix/not scroll tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mui/icons-material": "^6.1.6",
         "@mui/material": "^6.1.6",
         "@mui/styled-engine-sc": "^6.1.6",
-        "@mui/x-data-grid": "^7.22.0",
+        "@mui/x-data-grid": "^7.22.2",
         "@tanstack/react-query": "^5.59.16",
         "lucide-react": "^0.454.0",
         "next": "^15.0.2",
@@ -1784,9 +1784,9 @@
       }
     },
     "node_modules/@mui/x-data-grid": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-7.22.0.tgz",
-      "integrity": "sha512-gXl7+hG0YRNU3YODlPvz6Q/9+EeUsPAWn/u2YMQmYTgwAxeY5QE3lY224VRnwM5v9SfTFheo1kzAKmXPdjb9tQ==",
+      "version": "7.22.2",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-7.22.2.tgz",
+      "integrity": "sha512-yfy2s5A6tbajQZiEdsba49T4FYb9F0WPrzbbG30dl1+sIiX4ZRX7ma44UIDGPZrsZv8xkkE+p8qeJxZ7OaMteA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.7",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@mui/icons-material": "^6.1.6",
     "@mui/material": "^6.1.6",
     "@mui/styled-engine-sc": "^6.1.6",
-    "@mui/x-data-grid": "^7.22.0",
+    "@mui/x-data-grid": "^7.22.2",
     "@tanstack/react-query": "^5.59.16",
     "lucide-react": "^0.454.0",
     "next": "^15.0.2",

--- a/src/components/ClientForm.tsx
+++ b/src/components/ClientForm.tsx
@@ -1,9 +1,9 @@
-import { ListClietnType } from '../types/ListClient.type';
+import { ListClientType } from '../types/ListClient.type';
 import { TextField, Box } from '@mui/material';
 
 type ClientFormProps = {
-    client: ListClietnType;
-    onChange: (updatedClient: ListClietnType) => void;
+    client: ListClientType;
+    onChange: (updatedClient: ListClientType) => void;
   };
   
   const ClientForm: React.FC<ClientFormProps> = ({ client, onChange }) => {

--- a/src/components/CreateClientModal.tsx
+++ b/src/components/CreateClientModal.tsx
@@ -2,16 +2,16 @@ import React, { useState, useEffect } from 'react';
 import { Dialog, DialogTitle, DialogContent, DialogActions, Button } from '@mui/material';
 import ClientForm from './ClientForm';
 import { createClient } from '../services/createClient.service';
-import { ListClietnType } from '../types/ListClient.type';
+import { ListClientType } from '../types/ListClient.type';
 
 type CreateClientModalProps = {
   open: boolean;
   onClose: () => void;
-  onClientCreated: (client: ListClietnType) => void;
+  onClientCreated: (client: ListClientType) => void;
 };
 
 const CreateClientModal: React.FC<CreateClientModalProps> = ({ open, onClose, onClientCreated }) => {
-  const initialClientState: ListClietnType = {
+  const initialClientState: ListClientType = {
     id: null,
     nit: '',
     name: '',
@@ -23,11 +23,11 @@ const CreateClientModal: React.FC<CreateClientModalProps> = ({ open, onClose, on
     active: true,
   };
 
-  const [client, setClient] = useState<ListClietnType>(initialClientState);
+  const [client, setClient] = useState<ListClientType>(initialClientState);
   const [isFormValid, setIsFormValid] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleClientChange = (updatedClient: ListClietnType) => {
+  const handleClientChange = (updatedClient: ListClientType) => {
     setClient(updatedClient);
   };
 

--- a/src/components/CustomPagination.tsx
+++ b/src/components/CustomPagination.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Pagination } from '@mui/material';
+
+type CustomPaginationProps = {
+  paginationModel: { pageSize: number; page: number };
+  setPaginationModel: (model: { pageSize: number; page: number }) => void;
+  totalPages: number;
+};
+
+const CustomPagination: React.FC<CustomPaginationProps> = ({ paginationModel, setPaginationModel, totalPages }) => {
+  const handleChange = (event: React.ChangeEvent<unknown>, value: number) => {
+    setPaginationModel({ ...paginationModel, page: value - 1 });
+  };
+
+  return (
+    <Pagination
+        count={totalPages}
+        page={paginationModel.page + 1}
+        onChange={handleChange}
+        sx={{ bgcolor: 'white'}}
+        shape="rounded"
+    />
+  );
+};
+
+export default CustomPagination;

--- a/src/components/CustomPagination.tsx
+++ b/src/components/CustomPagination.tsx
@@ -14,16 +14,17 @@ interface CustomPaginationProps {
 
 const CustomPagination: React.FC<CustomPaginationProps> = ({ paginationModel, setPaginationModel, totalPages }) => {
   const handlePageChange = (event: React.ChangeEvent<unknown>, newPage: number) => {
-    setPaginationModel((prevModel) => ({
+    setPaginationModel((prevModel: PaginationModel) => ({
       ...prevModel,
-      page: newPage,
+      page: newPage - 1, 
     }));
   };
 
   const handlePageSizeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    setPaginationModel((prevModel) => ({
+    setPaginationModel((prevModel: PaginationModel) => ({
       ...prevModel,
       pageSize: parseInt(event.target.value, 10),
+      page: 0, 
     }));
   };
 
@@ -42,9 +43,9 @@ const CustomPagination: React.FC<CustomPaginationProps> = ({ paginationModel, se
       </select>
       <Pagination
         count={totalPages}
-        page={paginationModel.page}
+        page={paginationModel.page + 1} 
         onChange={handlePageChange}
-        className="ml-auto"
+        sx={{ '& .MuiPaginationItem-root': { borderRadius: 1 },  bgcolor: 'background.paper' }}
       />
     </div>
   );

--- a/src/components/CustomPagination.tsx
+++ b/src/components/CustomPagination.tsx
@@ -13,7 +13,7 @@ interface CustomPaginationProps {
 }
 
 const CustomPagination: React.FC<CustomPaginationProps> = ({ paginationModel, setPaginationModel, totalPages }) => {
-  const handlePageChange = (event: React.ChangeEvent<unknown>, newPage: number) => {
+  const handlePageChange = (_: React.ChangeEvent<unknown>, newPage: number) => {
     setPaginationModel((prevModel: PaginationModel) => ({
       ...prevModel,
       page: newPage - 1, 

--- a/src/components/CustomPagination.tsx
+++ b/src/components/CustomPagination.tsx
@@ -1,25 +1,52 @@
 import React from 'react';
 import { Pagination } from '@mui/material';
 
-type CustomPaginationProps = {
-  paginationModel: { pageSize: number; page: number };
-  setPaginationModel: (model: { pageSize: number; page: number }) => void;
+interface PaginationModel {
+  page: number;
+  pageSize: number;
+}
+
+interface CustomPaginationProps {
+  paginationModel: PaginationModel;
+  setPaginationModel: React.Dispatch<React.SetStateAction<PaginationModel>>;
   totalPages: number;
-};
+}
 
 const CustomPagination: React.FC<CustomPaginationProps> = ({ paginationModel, setPaginationModel, totalPages }) => {
-  const handleChange = (event: React.ChangeEvent<unknown>, value: number) => {
-    setPaginationModel({ ...paginationModel, page: value - 1 });
+  const handlePageChange = (event: React.ChangeEvent<unknown>, newPage: number) => {
+    setPaginationModel((prevModel) => ({
+      ...prevModel,
+      page: newPage,
+    }));
+  };
+
+  const handlePageSizeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setPaginationModel((prevModel) => ({
+      ...prevModel,
+      pageSize: parseInt(event.target.value, 10),
+    }));
   };
 
   return (
-    <Pagination
+    <div className="flex items-center justify-between p-2">
+      <select
+        value={paginationModel.pageSize}
+        onChange={handlePageSizeChange}
+        className="p-2 border border-gray-300 rounded-md"
+      >
+        {[10, 20, 50, 100].map((size) => (
+          <option key={size} value={size}>
+            {size} rows
+          </option>
+        ))}
+      </select>
+      <Pagination
         count={totalPages}
-        page={paginationModel.page + 1}
-        onChange={handleChange}
-        sx={{ bgcolor: 'white'}}
-        shape="rounded"
-    />
+        page={paginationModel.page}
+        onChange={handlePageChange}
+        className="ml-auto"
+      />
+    </div>
   );
 };
 

--- a/src/components/ListClients.tsx
+++ b/src/components/ListClients.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import CustomPagination from './CustomPagination';
 import { DataGrid, GridColDef, GridPaginationModel, GridToolbar } from "@mui/x-data-grid";
 import { Select, MenuItem,Button, Modal, Box, IconButton } from "@mui/material";
@@ -136,6 +136,11 @@ function ClientTable() {
   if (isLoading) return <Spinner />;
   if (isError || error) return <ErrorComponent message={error || 'Error loading clients'} />;
 
+  const ListClients = () => {
+    const [paginationModel, setPaginationModel] = React.useState({ page: 0, pageSize: 10 });
+    const totalPages = Math.ceil((clients?.length || 0) / paginationModel.pageSize);
+  }
+
   return (
     <div className="container mx-auto mt-10">
       <h1 className="text-center text-6xl font-extrabold mb-10 text-transparent bg-clip-text bg-gradient-to-r from-gray-800 via-black-500 to-gray-600 ">
@@ -146,25 +151,34 @@ function ClientTable() {
         New Client
       </Button>
 
-      <div className="w-full h-[40rem] overflow-y-auto">
-      <DataGrid
-        columns={columns.map(column => column.field === 'id' ? { ...column, width: 65 } : { ...column, flex: 1 })}
-        rows={clients || []}
-        style={{ height: '100%', width: '100%' }}
-        paginationModel={paginationModel}
-        getRowClassName={(params) => params.row.active ? '' : 'text-red-500 bg-red-100'}
-        onPaginationModelChange={(model) => setPaginationModel(model)}
-        slots={{
-          pagination: () => <CustomPagination paginationModel={paginationModel} setPaginationModel={setPaginationModel} totalPages={totalPages} />,
-        }}
-        classes={{
-          root: 'bg-white shadow-md rounded-lg',
-          columnHeader: 'bg-gray-700 text-white shadow-lg border-b border-gray-700',
-          row: 'hover:bg-gray-100',
-        }}
-      />
-    </div>
 
+      <div className="w-full h-[40rem] overflow-y-auto">
+  <DataGrid
+    columns={columns.map(column => column.field === 'id' ? { ...column, width: 65 } : { ...column, flex: 1 })}
+    rows={clients || []}
+    style={{ height: '100%', width: '100%' }}
+    slots={{
+      pagination: () => (
+        <CustomPagination 
+          paginationModel={paginationModel} 
+          setPaginationModel={setPaginationModel} 
+          totalPages={totalPages} 
+        />
+      ),
+    }}
+    pageSizeOptions={[10, 20, 50, 100]}
+    paginationModel={paginationModel}
+    onPaginationModelChange={(model) => {
+      setPaginationModel(model);
+      setPageSize(model.pageSize);
+    }}
+    classes={{
+      root: 'bg-white shadow-md rounded-lg',
+      columnHeader: 'bg-gray-700 text-white shadow-lg border-b border-gray-700',
+      row: 'hover:bg-gray-100',
+    }}
+  />
+</div>
       <Modal open={openModal} onClose={handleCloseModal}>
         <Box
           sx={{

--- a/src/components/ListClients.tsx
+++ b/src/components/ListClients.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
-import { DataGrid, GridColDef, GridPaginationModel } from "@mui/x-data-grid";
-import { Button, Modal, Box, IconButton } from "@mui/material";
+import CustomPagination from './CustomPagination';
+import { DataGrid, GridColDef, GridPaginationModel, GridToolbar } from "@mui/x-data-grid";
+import { Select, MenuItem,Button, Modal, Box, IconButton } from "@mui/material";
 import { useGetClients } from "../hooks/useGetClients";
 import { useToggleActive } from "../hooks/useToggleActive";
 import ClienteDetalle from './ClienteDetalle';
@@ -19,6 +20,8 @@ function ClientTable() {
   const [openCreateModal, setOpenCreateModal] = useState(false);
   const [openUpdateModal, setOpenUpdateModal] = useState(false);
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({ pageSize: 10, page: 0 });
+  const [pageSize, setPageSize] = useState<number>(10);
+  const [page, setPage] = useState<number>(0);
 
   useEffect(() => {
     if (clientsData) {
@@ -79,6 +82,8 @@ function ClientTable() {
       )
     );
   };
+
+  const totalPages = Math.ceil(clients.length / pageSize);
 
   const columns: GridColDef[] = [
     { field: "id", headerName: "ID", width: 100 },
@@ -143,14 +148,14 @@ function ClientTable() {
 
       <div className="w-full h-[40rem] overflow-y-auto">
       <DataGrid
-        columns={columns.map(column => column.field === 'id' ? { ...column, width: 65  } : { ...column, flex: 1 })}
+        columns={columns.map(column => column.field === 'id' ? { ...column, width: 65 } : { ...column, flex: 1 })}
         rows={clients || []}
         style={{ height: '100%', width: '100%' }}
-        getRowClassName={(params) => params.row.active ? '' : 'text-red-500 bg-red-100'}
-        pagination
         paginationModel={paginationModel}
-        onPaginationModelChange={setPaginationModel}
-        pageSizeOptions={[10, 25, 50]}
+        onPaginationModelChange={(model) => setPaginationModel(model)}
+        slots={{
+          pagination: () => <CustomPagination paginationModel={paginationModel} setPaginationModel={setPaginationModel} totalPages={totalPages} />,
+        }}
         classes={{
           root: 'bg-white shadow-md rounded-lg',
           columnHeader: 'bg-gray-700 text-white shadow-lg border-b border-gray-700',

--- a/src/components/ListClients.tsx
+++ b/src/components/ListClients.tsx
@@ -166,7 +166,7 @@ function ClientTable() {
     paginationModel={paginationModel}
     onPaginationModelChange={(model) => {
       setPaginationModel({ ...model, page: 1 });
-      setPageSize(model.pageSize);
+      setPageSize(pageSize);
     }}
     classes={{
       root: 'bg-white shadow-md rounded-lg',

--- a/src/components/ListClients.tsx
+++ b/src/components/ListClients.tsx
@@ -20,7 +20,7 @@ function ClientTable() {
   const [openCreateModal, setOpenCreateModal] = useState(false);
   const [openUpdateModal, setOpenUpdateModal] = useState(false);
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({ pageSize: 10, page: 0 });
-  const [pageSize, setPageSize] = useState<number>(10);
+  const [pageSize, setPageSize] = useState(10);
 
 
   useEffect(() => {

--- a/src/components/ListClients.tsx
+++ b/src/components/ListClients.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import { DataGrid, GridColDef, GridPaginationModel } from "@mui/x-data-grid";
 import { Button, Modal, Box, IconButton } from "@mui/material";
 import { useGetClients } from "../hooks/useGetClients";
 import { useToggleActive } from "../hooks/useToggleActive";
@@ -8,7 +8,7 @@ import CreateClientModal from './CreateClientModal';
 import Spinner from "./Spinner";
 import ErrorComponent from './Error-component';
 import CloseIcon from '@mui/icons-material/Close';
-import { ListClietnType } from '../types/ListClient.type';
+import { ListClientType } from '../types/ListClient.type';
 import UpdateClientModal from './UpdateClientModal';
 
 function ClientTable() {
@@ -17,7 +17,8 @@ function ClientTable() {
   const [openModal, setOpenModal] = useState(false);
   const [selectedClientId, setSelectedClientId] = useState<number | null>(null);
   const [openCreateModal, setOpenCreateModal] = useState(false);
-  const [openUpdateModal, setOpenUpdateModal] = useState(false); // Estado para el modal de actualización
+  const [openUpdateModal, setOpenUpdateModal] = useState(false);
+  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({ pageSize: 10, page: 0 });
 
   useEffect(() => {
     if (clientsData) {
@@ -57,7 +58,7 @@ function ClientTable() {
     setOpenCreateModal(false);
   };
 
-  const handleClientCreated = (newClient: ListClietnType) => {
+  const handleClientCreated = (newClient: ListClientType) => {
     setClients([...clients, newClient]);
   };
 
@@ -71,7 +72,7 @@ function ClientTable() {
     setSelectedClientId(null);
   };
 
-  const handleClientUpdated = (updatedClient: ListClietnType) => {
+  const handleClientUpdated = (updatedClient: ListClientType) => {
     setClients((prevClients) =>
       prevClients.map((client) =>
         client.id === updatedClient.id ? updatedClient : client
@@ -146,6 +147,10 @@ function ClientTable() {
         rows={clients || []}
         style={{ height: '100%', width: '100%' }}
         getRowClassName={(params) => params.row.active ? '' : 'text-red-500 bg-red-100'}
+        pagination
+        paginationModel={paginationModel}
+        onPaginationModelChange={setPaginationModel}
+        pageSizeOptions={[10, 25, 50]}
         classes={{
           root: 'bg-white shadow-md rounded-lg',
           columnHeader: 'bg-gray-700 text-white shadow-lg border-b border-gray-700',

--- a/src/components/ListClients.tsx
+++ b/src/components/ListClients.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import CustomPagination from './CustomPagination';
-import { DataGrid, GridColDef, GridPaginationModel, GridToolbar } from "@mui/x-data-grid";
-import { Select, MenuItem,Button, Modal, Box, IconButton } from "@mui/material";
+import { DataGrid, GridColDef, GridPaginationModel} from "@mui/x-data-grid";
+import { Button, Modal, Box, IconButton } from "@mui/material";
 import { useGetClients } from "../hooks/useGetClients";
 import { useToggleActive } from "../hooks/useToggleActive";
 import ClienteDetalle from './ClienteDetalle';
@@ -21,7 +21,7 @@ function ClientTable() {
   const [openUpdateModal, setOpenUpdateModal] = useState(false);
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({ pageSize: 10, page: 0 });
   const [pageSize, setPageSize] = useState<number>(10);
-  const [page, setPage] = useState<number>(0);
+
 
   useEffect(() => {
     if (clientsData) {
@@ -83,7 +83,7 @@ function ClientTable() {
     );
   };
 
-  const totalPages = Math.ceil(clients.length / pageSize);
+  const totalPages = Math.ceil(clients.length / paginationModel.pageSize);
 
   const columns: GridColDef[] = [
     { field: "id", headerName: "ID", width: 100 },
@@ -136,10 +136,6 @@ function ClientTable() {
   if (isLoading) return <Spinner />;
   if (isError || error) return <ErrorComponent message={error || 'Error loading clients'} />;
 
-  const ListClients = () => {
-    const [paginationModel, setPaginationModel] = React.useState({ page: 0, pageSize: 10 });
-    const totalPages = Math.ceil((clients?.length || 0) / paginationModel.pageSize);
-  }
 
   return (
     <div className="container mx-auto mt-10">
@@ -169,7 +165,7 @@ function ClientTable() {
     pageSizeOptions={[10, 20, 50, 100]}
     paginationModel={paginationModel}
     onPaginationModelChange={(model) => {
-      setPaginationModel(model);
+      setPaginationModel({ ...model, page: 1 });
       setPageSize(model.pageSize);
     }}
     classes={{
@@ -177,6 +173,7 @@ function ClientTable() {
       columnHeader: 'bg-gray-700 text-white shadow-lg border-b border-gray-700',
       row: 'hover:bg-gray-100',
     }}
+
   />
 </div>
       <Modal open={openModal} onClose={handleCloseModal}>

--- a/src/components/ListClients.tsx
+++ b/src/components/ListClients.tsx
@@ -148,7 +148,7 @@ function ClientTable() {
       </Button>
 
 
-      <div className="w-full h-[40rem] overflow-y-auto">
+  <div className="w-full h-[40rem] overflow-y-auto">
   <DataGrid
     columns={columns.map(column => column.field === 'id' ? { ...column, width: 65 } : { ...column, flex: 1 })}
     rows={clients || []}

--- a/src/components/ListClients.tsx
+++ b/src/components/ListClients.tsx
@@ -153,6 +153,7 @@ function ClientTable() {
     columns={columns.map(column => column.field === 'id' ? { ...column, width: 65 } : { ...column, flex: 1 })}
     rows={clients || []}
     style={{ height: '100%', width: '100%' }}
+    getRowClassName={(params) => params.row.active ? '' : 'text-red-500 bg-red-100'}
     slots={{
       pagination: () => (
         <CustomPagination 

--- a/src/components/ListClients.tsx
+++ b/src/components/ListClients.tsx
@@ -152,6 +152,7 @@ function ClientTable() {
         rows={clients || []}
         style={{ height: '100%', width: '100%' }}
         paginationModel={paginationModel}
+        getRowClassName={(params) => params.row.active ? '' : 'text-red-500 bg-red-100'}
         onPaginationModelChange={(model) => setPaginationModel(model)}
         slots={{
           pagination: () => <CustomPagination paginationModel={paginationModel} setPaginationModel={setPaginationModel} totalPages={totalPages} />,

--- a/src/components/ListOpportunities.tsx
+++ b/src/components/ListOpportunities.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { DataGrid, GridColDef } from "@mui/x-data-grid";
+import { DataGrid, GridColDef, GridPaginationModel } from "@mui/x-data-grid";
 import { Button, Tooltip } from "@mui/material";
 import Spinner from "./Spinner";
 import ErrorComponent from './Error-component';
@@ -20,6 +20,8 @@ function OpportunitiesTable({ clientId, showSeguimiento = false, onSeguimientoCl
   
   const [selectedOpportunity, setSelectedOpportunity] = useState<IOpportunity | null>(null);
   const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
+
+  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({ pageSize: 10, page: 0 });
 
   const handleOpenUpdateModal = (opportunity: IOpportunity) => {
     setSelectedOpportunity(opportunity);
@@ -147,6 +149,10 @@ function OpportunitiesTable({ clientId, showSeguimiento = false, onSeguimientoCl
           columns={columns.map(column => column.field === 'id' ? { ...column, width: 65  } : { ...column, flex: 1 })} 
           rows={opportunities || []} 
           style={{height: 'auto', width: '100%'}}
+          pagination
+          paginationModel={paginationModel}
+          onPaginationModelChange={setPaginationModel}
+          pageSizeOptions={[10, 25, 50]}
           classes={{
             root: 'bg-white shadow-md rounded-lg',
             columnHeader: 'bg-gray-700 text-white shadow-lg border-b border-gray-700',

--- a/src/components/ListOpportunities.tsx
+++ b/src/components/ListOpportunities.tsx
@@ -7,20 +7,19 @@ import { useGetOpportunities } from '../hooks/useGetOpportunities';
 import { formatCurrency } from '../utils/formatCurrency';
 import UpdateOpportunityModal from './UpdateOpportunityModal';
 import { IOpportunity } from '../types/ListOpportunity.type';
+import CustomPagination from './CustomPagination';
 
 interface OpportunitiesTableProps {
   clientId?: number;
   showSeguimiento?: boolean;
-  onSeguimientoClick?: (id: number, name: string) => void; // Pass both id and name
+  onSeguimientoClick?: (id: number, name: string) => void;
 }
 
 function OpportunitiesTable({ clientId, showSeguimiento = false, onSeguimientoClick }: OpportunitiesTableProps) {
   const { data: opportunityData, isError, isLoading } = useGetOpportunities(clientId);
   const [opportunities, setOpportunities] = useState(opportunityData || []);
-  
   const [selectedOpportunity, setSelectedOpportunity] = useState<IOpportunity | null>(null);
   const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
-
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({ pageSize: 10, page: 0 });
 
   const handleOpenUpdateModal = (opportunity: IOpportunity) => {
@@ -34,62 +33,60 @@ function OpportunitiesTable({ clientId, showSeguimiento = false, onSeguimientoCl
   };
 
   const handleOpportunityUpdated = (updatedOpportunity: IOpportunity) => {
-
     setOpportunities((prevOpportunities) =>
       prevOpportunities.map((opp) =>
         opp.id === updatedOpportunity.id ? updatedOpportunity : opp
       )
     );
   };
-  
+
   useEffect(() => {
     if (opportunityData) {
-        setOpportunities(opportunityData);
+      setOpportunities(opportunityData);
     }
   }, [opportunityData]);
 
   const columns: GridColDef[] = [
     { field: "id", headerName: "ID", width: 100 },
     { 
-        field: "clientIds", 
-        headerName: "Clients", 
-        width: 150,
-
-        renderCell: (params) => {
-          const clientIds = Array.isArray(params.value) ? params.value.join(', ') : params.value;
-          return (
-            <Tooltip title={clientIds}>
-              <span>{clientIds.length > 20 ? `${clientIds.slice(0, 20)}...` : clientIds}</span>
-            </Tooltip>
-          );
-        }
+      field: "clientIds", 
+      headerName: "Clients", 
+      width: 150,
+      renderCell: (params) => {
+        const clientIds = Array.isArray(params.value) ? params.value.join(', ') : params.value;
+        return (
+          <Tooltip title={clientIds}>
+            <span>{clientIds.length > 20 ? `${clientIds.slice(0, 20)}...` : clientIds}</span>
+          </Tooltip>
+        );
+      }
     },
     { 
-        field: "businessName", 
-        headerName: "Business Name", 
-        width: 200,
-        renderCell: (params) => (
-          <Tooltip title={params.value}>
-            <span>{params.value.length > 20 ? `${params.value.slice(0, 20)}...` : params.value}</span>
-          </Tooltip>
-        )
+      field: "businessName", 
+      headerName: "Business Name", 
+      width: 200,
+      renderCell: (params) => (
+        <Tooltip title={params.value}>
+          <span>{params.value.length > 20 ? `${params.value.slice(0, 20)}...` : params.value}</span>
+        </Tooltip>
+      )
     },
     { field: "businessLine", headerName: "Business Line", width: 200 },
     { 
-        field: "description", 
-        headerName: "Description", 
-        width: 150,
-        renderCell: (params) => (
-          <Tooltip title={params.value}>
-            <span>{params.value.length > 20 ? `${params.value.slice(0, 20)}...` : params.value}</span>
-          </Tooltip>
-        )
+      field: "description", 
+      headerName: "Description", 
+      width: 150,
+      renderCell: (params) => (
+        <Tooltip title={params.value}>
+          <span>{params.value.length > 20 ? `${params.value.slice(0, 20)}...` : params.value}</span>
+        </Tooltip>
+      )
     },
     {
-        field: "estimatedValue",
-        headerName: "Estimated Value",
-        width: 150,
-        renderCell: (params) => formatCurrency(params.value),
+      field: "estimatedValue",
+      headerName: "Estimated Value",
+      width: 150,
+      renderCell: (params) => formatCurrency(params.value),
     },
     { field: "estimatedDate", headerName: "Estimated Date", width: 150 },
     { field: "status", headerName: "Status", width: 150 },
@@ -140,19 +137,30 @@ function OpportunitiesTable({ clientId, showSeguimiento = false, onSeguimientoCl
   ];
 
   if (isLoading) return <Spinner/>;
-  if (isError) return ErrorComponent({ message:'Error loading Opportunities' });
+  if (isError) return <ErrorComponent message='Error loading Opportunities' />;
+
+  const totalPages = Math.ceil(opportunities.length / paginationModel.pageSize);
 
   return (
-    <div className="container mx-auto">
+    <div className="container mx-auto mt-10">
       <div className="w-full h-[40rem] overflow-y-auto">
-	    <DataGrid 
+        <DataGrid 
           columns={columns.map(column => column.field === 'id' ? { ...column, width: 65  } : { ...column, flex: 1 })} 
           rows={opportunities || []} 
-          style={{height: 'auto', width: '100%'}}
+          style={{height: '100%', width: '100%'}}
           pagination
           paginationModel={paginationModel}
           onPaginationModelChange={setPaginationModel}
-          pageSizeOptions={[10, 25, 50]}
+          pageSizeOptions={[10, 20, 50, 100]}
+          slots={{
+            pagination: () => (
+              <CustomPagination 
+                paginationModel={paginationModel} 
+                setPaginationModel={setPaginationModel} 
+                totalPages={totalPages} 
+              />
+            ),
+          }}
           classes={{
             root: 'bg-white shadow-md rounded-lg',
             columnHeader: 'bg-gray-700 text-white shadow-lg border-b border-gray-700',
@@ -167,7 +175,6 @@ function OpportunitiesTable({ clientId, showSeguimiento = false, onSeguimientoCl
         onOpportunityUpdated={handleOpportunityUpdated}
       />
     </div>
-    
   );
 }
 

--- a/src/components/UpdateClientModal.tsx
+++ b/src/components/UpdateClientModal.tsx
@@ -5,17 +5,17 @@ import ClientForm from './ClientForm';
 import Spinner from "./Spinner";
 import ErrorComponent from './Error-component';
 import { fetchClientById, updateClient } from '../services/createClient.service';
-import { ListClietnType } from '../types/ListClient.type';
+import { ListClientType } from '../types/ListClient.type';
 
 type UpdateClientModalProps = {
   open: boolean;
   onClose: () => void;
   clientId: number;
-  onClientUpdated: (client: ListClietnType) => void;
+  onClientUpdated: (client: ListClientType) => void;
 };
 
 const UpdateClientModal: React.FC<UpdateClientModalProps> = ({ open, onClose, clientId, onClientUpdated }) => {
-  const [client, setClient] = useState<ListClietnType | null>(null);
+  const [client, setClient] = useState<ListClientType | null>(null);
   const [isFormValid, setIsFormValid] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -25,7 +25,7 @@ const UpdateClientModal: React.FC<UpdateClientModalProps> = ({ open, onClose, cl
       setLoading(true);
       setError(null);
       try {
-        const clientData: ListClietnType = await fetchClientById(clientId);
+        const clientData: ListClientType = await fetchClientById(clientId);
         setClient(clientData);
       } catch (error) {
         setError('Error loading client data'); 
@@ -46,7 +46,7 @@ const UpdateClientModal: React.FC<UpdateClientModalProps> = ({ open, onClose, cl
     setIsFormValid(validateForm());
   }, [client]);
 
-  const handleClientChange = (updatedClient: ListClietnType) => {
+  const handleClientChange = (updatedClient: ListClientType) => {
     setClient(updatedClient);
   };
 

--- a/src/components/UpdateOportunityForm.tsx
+++ b/src/components/UpdateOportunityForm.tsx
@@ -12,8 +12,9 @@ const OpportunityForm: React.FC<OpportunityFormProps> = ({ opportunity, onChange
     const { name, value } = e.target;
     onChange({ ...opportunity, [name]: name === 'estimatedValue' ? Number(value) : value });
   };
-
+  
   return (
+    
     <form>
       <TextField
         label="Business Name"
@@ -31,8 +32,14 @@ const OpportunityForm: React.FC<OpportunityFormProps> = ({ opportunity, onChange
         onChange={handleChange}
         fullWidth
         margin="normal"
+        select
         required={true}
-      />
+      >
+        <MenuItem value="Outsourcing Resource">Outsourcing Resource</MenuItem>
+        <MenuItem value="Web Development">Web Development</MenuItem>
+        <MenuItem value="Mobile Development">Mobile Development</MenuItem>
+        <MenuItem value="IT Consulting">IT Consulting</MenuItem>
+      </TextField>
       <TextField
         label="Description"
         name="description"

--- a/src/components/UpdateOportunityForm.tsx
+++ b/src/components/UpdateOportunityForm.tsx
@@ -35,7 +35,7 @@ const OpportunityForm: React.FC<OpportunityFormProps> = ({ opportunity, onChange
         select
         required={true}
       >
-        <MenuItem value="Outsourcing Resource">Outsourcing Resource</MenuItem>
+        <MenuItem value="Outsourcing Resources">Outsourcing Resources</MenuItem>
         <MenuItem value="Web Development">Web Development</MenuItem>
         <MenuItem value="Mobile Development">Mobile Development</MenuItem>
         <MenuItem value="IT Consulting">IT Consulting</MenuItem>

--- a/src/components/UpdateOportunityForm.tsx
+++ b/src/components/UpdateOportunityForm.tsx
@@ -35,7 +35,7 @@ const OpportunityForm: React.FC<OpportunityFormProps> = ({ opportunity, onChange
         select
         required={true}
       >
-        <MenuItem value="Outsourcing Resources">Outsourcing Resources</MenuItem>
+        <MenuItem value="Outsourcing Resources">Outsourcing Resource</MenuItem>
         <MenuItem value="Web Development">Web Development</MenuItem>
         <MenuItem value="Mobile Development">Mobile Development</MenuItem>
         <MenuItem value="IT Consulting">IT Consulting</MenuItem>

--- a/src/components/UpdateOpportunityModal.tsx
+++ b/src/components/UpdateOpportunityModal.tsx
@@ -47,7 +47,7 @@ const UpdateOpportunityModal: React.FC<UpdateOpportunityModalProps> = ({ open, o
 
   useEffect(() => {
     const validateForm = () => {
-      const validStatuses = ["Open", "Under Review", "Purchase Order", "Completed"];
+      const validStatuses = ["Open", "In Study", "Purchase Order", "Finalized"];
       return opportunity !== null && opportunity.businessName !== '' && opportunity.businessLine && opportunity.description !== '' && opportunity.estimatedValue > 0 && opportunity.estimatedDate !== '' && validStatuses.includes(opportunity.status);
     };
     setIsFormValid(validateForm());

--- a/src/services/createClient.service.ts
+++ b/src/services/createClient.service.ts
@@ -1,9 +1,9 @@
 // services/clientService.ts
-import { ListClietnType } from '../types/ListClient.type';
+import { ListClientType } from '../types/ListClient.type';
 
 const API_URL = 'https://web-fe-prj3-api-apollo.onrender.com';
 
-export const createClient = async (client: ListClietnType) => {
+export const createClient = async (client: ListClientType) => {
   const response = await fetch(`${API_URL}/clients`, {
     method: 'POST',
     headers: {
@@ -20,7 +20,7 @@ export const createClient = async (client: ListClietnType) => {
 };
 
 // Función para obtener un cliente específico por ID (NIT en este caso)
-export const fetchClientById = async (id: number): Promise<ListClietnType> => {
+export const fetchClientById = async (id: number): Promise<ListClientType> => {
     const response = await fetch(`${API_URL}/clients/${id}`, {
       method: 'GET',
       headers: {
@@ -36,7 +36,7 @@ export const fetchClientById = async (id: number): Promise<ListClietnType> => {
   };
 
 // Función para actualizar un cliente
-export const updateClient = async (client: ListClietnType): Promise<ListClietnType> => {
+export const updateClient = async (client: ListClientType): Promise<ListClientType> => {
   const response = await fetch(`${API_URL}/clients/${client.id}`, {
     method: 'PUT',
     headers: {

--- a/src/services/getClients.service.ts
+++ b/src/services/getClients.service.ts
@@ -1,6 +1,6 @@
 import { fetcher } from "./api.service";
-import { ListClietnType } from "../types/ListClient.type";
+import { ListClientType } from "../types/ListClient.type";
 
-export const useGetclients = async (): Promise<ListClietnType[]> => {
+export const useGetclients = async (): Promise<ListClientType[]> => {
     return fetcher("/clients");
 };

--- a/src/types/ListClient.type.ts
+++ b/src/types/ListClient.type.ts
@@ -12,5 +12,5 @@ export type Opportunity = {
     phone: string;
     email: string;
     active: boolean;
-    opportunities: Opportunity[]; 
+    opportunities?: Opportunity[]; 
 };


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/de87578b-bf29-42c4-bb53-0d44a8eba3f2)

Se le agregaron nuevas mejoras a las tablas para la accesibilidad:

Ahora están paginadas y se le puede cambiar el número de rows que se ven en pantalla dinámicamente, como default están en 10 para que no sea necesario el scroll sino únicamente el cambio de páginas.

Se arregló una parte del update de oportunidades que no desprendía un menú en la columna de businessLine

![image](https://github.com/user-attachments/assets/369d8b61-9ddb-405c-9691-29a243253489)
